### PR TITLE
Fix login form rendering issue

### DIFF
--- a/includes/Renderer/MyAccount.php
+++ b/includes/Renderer/MyAccount.php
@@ -14,7 +14,7 @@ class MyAccount {
         if ( ! is_user_logged_in() ) {
             $this->show_login_form();
 
-            return;
+            return ob_get_clean();
         }
 
         $affiliate = get_option( 'appsero_affiliate_wp_settings', '' );


### PR DESCRIPTION
This should fix the rending issue of the login form. The form is rendered immediately instead of rending where the short-code is placed.