### PR TITLE
Fix vendor_id should be a integer console error

### DIFF
--- a/assets/js/paddle-affiliate-wp.js
+++ b/assets/js/paddle-affiliate-wp.js
@@ -1,46 +1,46 @@
 function appseroSetupPaddle() {
     Paddle.Setup({
-        vendor: appseroPaddleAffWP.vendor_id,
-        eventCallback: function(data) {
+        vendor: parseInt(appseroPaddleAffWP.vendor_id),
+        eventCallback: function (data) {
             appseroPaddleEvent(data);
         },
     });
 }
 
-jQuery( document ).ready( function() {
+jQuery(document).ready(function () {
     appseroSetupAffiliatePaddle();
 });
 
 function appseroSetupAffiliatePaddle() {
-    if( window.Paddle === undefined || !window.Paddle ) {
+    if (window.Paddle === undefined || !window.Paddle) {
         return;
     }
 
-    if( window.PaddleCompletedSetup === undefined || !window.PaddleCompletedSetup ) {
+    if (
+        window.PaddleCompletedSetup === undefined ||
+        !window.PaddleCompletedSetup
+    ) {
         appseroSetupPaddle();
         return;
     }
 
     Paddle.Options({
-        eventCallback: function(data) {
+        eventCallback: function (data) {
             appseroPaddleEvent(data);
-        }
+        },
     });
 }
 
 function appseroPaddleEvent(data) {
-
-    if( data.event === 'Checkout.Complete' ) {
+    if (data.event === "Checkout.Complete") {
         appseroPaddleCheckoutComplete(data.eventData);
     }
 }
 
-
 function appseroPaddleCheckoutComplete(data) {
-
     const checkoutId = data.checkout.id;
 
-    if( !checkoutId ) {
+    if (!checkoutId) {
         return;
     }
 
@@ -49,7 +49,7 @@ function appseroPaddleCheckoutComplete(data) {
         type: "POST",
         data: {
             checkout_id: checkoutId,
-            action: 'appsero_affwp_paddle_completed'
+            action: "appsero_affwp_paddle_completed",
         },
     });
 }

--- a/includes/SettingsPage.php
+++ b/includes/SettingsPage.php
@@ -363,6 +363,7 @@ class SettingsPage {
                 'fastspring_password' => sanitize_text_field( $post['fastspring_password'] ),
                 'enable_affiliates'   => ! empty( $post['enable_affiliates'] ),
                 'affiliate_area_page' => sanitize_text_field( $post['affiliate_area_page'] ),
+                'paddle_vendor_id' => sanitize_text_field( $post['paddle_vendor_id'] )
             ];
 
             update_option( 'appsero_affiliate_wp_settings', $userinfo, false );
@@ -374,7 +375,7 @@ class SettingsPage {
                 'paddle_vendor_auth_code' => sanitize_text_field( $post['paddle_vendor_auth_code'] ),
                 'paddle_sandbox' => ! empty( $post['paddle_sandbox'] ),
                 'enable_affiliates'   => ! empty( $post['enable_affiliates'] ),
-                'affiliate_area_page' => sanitize_text_field( $post['affiliate_area_page'] ),
+                'affiliate_area_page' => sanitize_text_field( $post['affiliate_area_page'] )
             ];
 
             update_option( 'appsero_affiliate_wp_settings', $userinfo, false );


### PR DESCRIPTION
For some reason there is a need of vendor id for paddle even if we use FastSpring. But the fields for paddle is hidden and not saving anything while paddle not selected. So I make sure at least the paddle vendor id field will remain save event if we change the payment solution. 

Another thing is on JavaScript we should must `parseInt` the `appseroPaddleAffWP.vendor_id` before using to confirm it's a integer. 