### PR TITLE
Fixed license download link in the woo email

### DIFF
--- a/includes/WooCommerce.php
+++ b/includes/WooCommerce.php
@@ -11,14 +11,15 @@ class WooCommerce {
      */
     public function __construct() {
         require_once __DIR__ . '/WooCommerce/UseCases/SendRequestsHelper.php';
-        require_once __DIR__ . '/WooCommerce/SendRequests.php';
+        require_once __DIR__ . '/WooCommerce/OrderHooks.php';
         require_once __DIR__ . '/WooCommerce/MyAccountPage.php';
         require_once __DIR__ . '/WooCommerce/ThankYouPage.php';
         require_once __DIR__ . '/WooCommerce/MetaBox.php';
         require_once __DIR__ . '/WooCommerce/Email.php';
 
         // Initialize WooCommerce requests hooks
-        new WooCommerce\SendRequests();
+//        new WooCommerce\SendRequests();
+        new WooCommerce\OrderHooks();
 
         // WooCommerce My Account page
         new WooCommerce\MyAccountPage();

--- a/includes/WooCommerce/Email.php
+++ b/includes/WooCommerce/Email.php
@@ -19,6 +19,10 @@ class Email {
             return '';
 
         $licenses = [];
+        if (! did_action('woocommerce_order_status_changed')) {
+            $request = new SendRequests();
+            $request->order_status_changed( $order->get_id(), '', '', $order);
+        }
 
         foreach ( $order->get_items( 'line_item' ) as $item_id => $item ) {
             $key = '_appsero_order_license_for_product_' . $item->get_product_id();

--- a/includes/WooCommerce/OrderHooks.php
+++ b/includes/WooCommerce/OrderHooks.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Appsero\Helper\WooCommerce;
+
+use Appsero\Helper\Traits\Hooker;
+
+class OrderHooks {
+    use Hooker;
+
+    public function __construct() {
+        require_once __DIR__ . '/SendRequests.php';
+        $sendRequest = new SendRequests();
+        // Add or Update order with license
+        add_action( 'woocommerce_order_status_changed', [ $sendRequest, 'receive_order_status_changed'], 20, 4 );
+        add_action( 'before_delete_post', [ $sendRequest, 'delete_order'], 8, 1 );
+    }
+}

--- a/includes/WooCommerce/SendRequests.php
+++ b/includes/WooCommerce/SendRequests.php
@@ -9,14 +9,13 @@ use Appsero\Helper\Traits\Hooker;
  */
 class SendRequests {
 
-    use Hooker;
     use UseCases\SendRequestsHelper;
 
-    public function __construct() {
-        // Add or Update order with license
-        $this->action( 'woocommerce_order_status_changed', 'order_status_changed', 20, 4 );
-
-        $this->action( 'before_delete_post', 'delete_order', 8, 1 );
+    public function receive_order_status_changed( $order_id, $status_from, $status_to, $order ) {
+        if (did_action('woocommerce_email_after_order_table')) {
+            return;
+        }
+        $this->order_status_changed( $order_id, $status_from, $status_to, $order );
     }
 
     /**


### PR DESCRIPTION
Fixed the Appsero license key & download link is not attached on the WooCommerce order confirmation mail

Resolved #https://github.com/Appsero/appsero-api/issues/238