### PR TITLE
Notify Appsero on customer updates

### DIFF
--- a/appsero-helper.php
+++ b/appsero-helper.php
@@ -5,7 +5,7 @@
  * Description: Helper plugin to connect WordPress store to Appsero
  * Author: Appsero
  * Author URI: https://appsero.com
- * Version: 1.3.0
+ * Version: 1.3.1
  * Text Domain: appsero-helper
  */
 

--- a/includes/Admin_Notice.php
+++ b/includes/Admin_Notice.php
@@ -21,6 +21,9 @@ class Admin_Notice {
         }
 
         add_action( 'admin_notices', [ $this, 'no_product_warning' ] );
+
+        add_action( 'profile_update', 'appsero_update_customer', 10, 2 );
+
     }
 
     /**


### PR DESCRIPTION
### Pull Request Description
This PR implements a feature to notify Appsero when a user is updated. The following changes have been made:

- **Functionality Added**: A new function, `appsero_update_customer`, has been implemented to send updated user information to the Appsero server upon editing a users's details.
- **Data Collection**: The function collects relevant user data, including email, name, phone, and billing information (address, state, country).
- **Country and State Names**: Country and state codes are converted to their respective full names before being sent in the notification request to ensure better clarity and usability on the Appsero side.
- **Endpoint**: The updates are sent to the `public/users/{user_id}/edit-customer` endpoint on the Appsero server.

This change enhances synchronization between WooCommerce customer data and Appsero, ensuring that any updates made to customer information are reflected accurately on the server. 

issue: https://github.com/Appsero/appsero-api/issues/329