### PR TITLE
Add outgoing webhook support

### DIFF
--- a/appsero-helper.php
+++ b/appsero-helper.php
@@ -232,6 +232,9 @@ final class Appsero_Helper {
 
         new Appsero\Helper\Common\Filter_Hook();
 
+        // Include Webhook classes
+        $this->webhook_includes();
+
         // Include AffiliateWP classes
         $this->affiliate_wp_includes();
     }
@@ -273,6 +276,18 @@ final class Appsero_Helper {
         }
 
         return false;
+    }
+
+    /**
+     * Load Webhook classes
+     */
+    private function webhook_includes() {
+        require_once __DIR__ . '/includes/Webhooks/Repository.php';
+        require_once __DIR__ . '/includes/Webhooks/Dispatcher.php';
+        require_once __DIR__ . '/includes/Webhooks/EventListener.php';
+        require_once __DIR__ . '/includes/Webhooks/WebhooksPage.php';
+
+        new Appsero\Helper\Webhooks\EventListener();
     }
 
     /**

--- a/includes/SettingsPage.php
+++ b/includes/SettingsPage.php
@@ -80,6 +80,9 @@ class SettingsPage {
             $this->save_settings_fields( $_POST );
         }
 
+        $webhooks_page = new \Appsero\Helper\Webhooks\WebhooksPage();
+        $webhooks_page->handle_post();
+
         $token = isset( $this->connection['token'] ) ? $this->connection['token'] : '';
         $button_class = '';
 
@@ -277,6 +280,8 @@ class SettingsPage {
                 </form>
 
             </div>
+
+            <?php $webhooks_page->render(); ?>
         </div>
 
         <?php

--- a/includes/Webhooks/Dispatcher.php
+++ b/includes/Webhooks/Dispatcher.php
@@ -1,0 +1,60 @@
+<?php
+namespace Appsero\Helper\Webhooks;
+
+class Dispatcher {
+
+    /**
+     * @var Repository
+     */
+    private $repository;
+
+    public function __construct( Repository $repository = null ) {
+        $this->repository = $repository ?: new Repository();
+    }
+
+    /**
+     * Dispatch an event to all active webhooks listening for it
+     *
+     * @param string $event
+     * @param array  $data
+     */
+    public function dispatch( $event, $data ) {
+        $webhooks = $this->repository->get_active_for_event( $event );
+
+        foreach ( $webhooks as $webhook ) {
+            $this->deliver( $webhook, $event, $data );
+        }
+    }
+
+    /**
+     * Deliver a payload to a single webhook URL
+     *
+     * @param array  $webhook
+     * @param string $event
+     * @param array  $data
+     */
+    private function deliver( $webhook, $event, $data ) {
+        $payload = wp_json_encode( [
+            'event'     => $event,
+            'timestamp' => time(),
+            'data'      => $data,
+        ] );
+
+        $headers = [
+            'Content-Type' => 'application/json',
+            'X-Api-Key'    => appsero_helper_get_api_key(),
+        ];
+
+        if ( ! empty( $webhook['secret'] ) ) {
+            $signature = hash_hmac( 'sha256', $payload, $webhook['secret'] );
+            $headers['X-Appsero-Signature'] = 'sha256=' . $signature;
+        }
+
+        wp_remote_post( $webhook['url'], [
+            'body'     => $payload,
+            'headers'  => $headers,
+            'timeout'  => 5,
+            'blocking' => false,
+        ] );
+    }
+}

--- a/includes/Webhooks/EventListener.php
+++ b/includes/Webhooks/EventListener.php
@@ -1,0 +1,35 @@
+<?php
+namespace Appsero\Helper\Webhooks;
+
+use Appsero\Helper\Traits\Hooker;
+
+class EventListener {
+
+    use Hooker;
+
+    /**
+     * @var Dispatcher
+     */
+    private $dispatcher;
+
+    public function __construct() {
+        $this->dispatcher = new Dispatcher();
+
+        $this->action( 'appsero_user_created', 'on_user_created', 10, 2 );
+    }
+
+    /**
+     * Handle user created event
+     *
+     * @param int   $user_id
+     * @param array $userdata
+     */
+    public function on_user_created( $user_id, $userdata ) {
+        $this->dispatcher->dispatch( 'user.created', [
+            'user_id'    => $user_id,
+            'email'      => $userdata['user_email'],
+            'first_name' => $userdata['first_name'],
+            'last_name'  => $userdata['last_name'],
+        ] );
+    }
+}

--- a/includes/Webhooks/Repository.php
+++ b/includes/Webhooks/Repository.php
@@ -1,0 +1,78 @@
+<?php
+namespace Appsero\Helper\Webhooks;
+
+class Repository {
+
+    const OPTION_KEY = 'appsero_webhooks';
+
+    /**
+     * Get all webhooks
+     *
+     * @return array
+     */
+    public function get_all() {
+        return get_option( self::OPTION_KEY, [] );
+    }
+
+    /**
+     * Get active webhooks for a specific event
+     *
+     * @param string $event
+     * @return array
+     */
+    public function get_active_for_event( $event ) {
+        $webhooks = $this->get_all();
+
+        return array_filter( $webhooks, function ( $webhook ) use ( $event ) {
+            return ! empty( $webhook['status'] )
+                && is_array( $webhook['events'] )
+                && in_array( $event, $webhook['events'], true );
+        } );
+    }
+
+    /**
+     * Create a new webhook
+     *
+     * @param array $data
+     * @return string The new webhook ID
+     */
+    public function create( $data ) {
+        $webhooks = $this->get_all();
+
+        $id = uniqid( 'wh_' );
+
+        $webhooks[ $id ] = [
+            'id'         => $id,
+            'name'       => sanitize_text_field( $data['name'] ),
+            'url'        => esc_url_raw( $data['url'] ),
+            'secret'     => sanitize_text_field( $data['secret'] ),
+            'events'     => array_map( 'sanitize_text_field', $data['events'] ),
+            'status'     => 1,
+            'created_at' => current_time( 'mysql' ),
+        ];
+
+        update_option( self::OPTION_KEY, $webhooks, false );
+
+        return $id;
+    }
+
+    /**
+     * Delete a webhook by ID
+     *
+     * @param string $id
+     * @return bool
+     */
+    public function delete( $id ) {
+        $webhooks = $this->get_all();
+
+        if ( ! isset( $webhooks[ $id ] ) ) {
+            return false;
+        }
+
+        unset( $webhooks[ $id ] );
+
+        update_option( self::OPTION_KEY, $webhooks, false );
+
+        return true;
+    }
+}

--- a/includes/Webhooks/WebhooksPage.php
+++ b/includes/Webhooks/WebhooksPage.php
@@ -1,0 +1,185 @@
+<?php
+namespace Appsero\Helper\Webhooks;
+
+class WebhooksPage {
+
+    /**
+     * @var Repository
+     */
+    private $repository;
+
+    /**
+     * @var string
+     */
+    private $message = '';
+
+    /**
+     * @var string
+     */
+    private $message_type = '';
+
+    /**
+     * Available webhook events
+     */
+    private static $available_events = [
+        'user.created' => 'User Created',
+    ];
+
+    public function __construct() {
+        $this->repository = new Repository();
+    }
+
+    /**
+     * Handle form submissions (add/delete)
+     */
+    public function handle_post() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+
+        // Handle delete
+        if ( isset( $_GET['action'] ) && $_GET['action'] === 'delete_webhook' && isset( $_GET['webhook_id'] ) ) {
+            if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( $_GET['_wpnonce'], 'delete_webhook_' . $_GET['webhook_id'] ) ) {
+                return;
+            }
+
+            $this->repository->delete( sanitize_text_field( $_GET['webhook_id'] ) );
+            $this->message      = 'Webhook deleted.';
+            $this->message_type = 'success';
+
+            return;
+        }
+
+        // Handle add
+        if ( ! isset( $_POST['appsero_webhook_submit'] ) ) {
+            return;
+        }
+
+        if ( ! isset( $_POST['appsero_webhook_nonce'] ) || ! wp_verify_nonce( $_POST['appsero_webhook_nonce'], 'appsero_add_webhook' ) ) {
+            $this->message      = 'Unauthorized request.';
+            $this->message_type = 'error';
+
+            return;
+        }
+
+        $name   = isset( $_POST['webhook_name'] ) ? sanitize_text_field( $_POST['webhook_name'] ) : '';
+        $url    = isset( $_POST['webhook_url'] ) ? esc_url_raw( $_POST['webhook_url'] ) : '';
+        $secret = isset( $_POST['webhook_secret'] ) ? sanitize_text_field( $_POST['webhook_secret'] ) : '';
+        $events = isset( $_POST['webhook_events'] ) ? array_map( 'sanitize_text_field', (array) $_POST['webhook_events'] ) : [];
+
+        if ( empty( $name ) || empty( $url ) || empty( $events ) ) {
+            $this->message      = 'Name, URL, and at least one event are required.';
+            $this->message_type = 'error';
+
+            return;
+        }
+
+        $this->repository->create( [
+            'name'   => $name,
+            'url'    => $url,
+            'secret' => $secret,
+            'events' => $events,
+        ] );
+
+        $this->message      = 'Webhook added.';
+        $this->message_type = 'success';
+    }
+
+    /**
+     * Render the webhooks section
+     */
+    public function render() {
+        $webhooks = $this->repository->get_all();
+        $page_url = admin_url( 'options-general.php?page=appsero_helper' );
+        ?>
+
+        <div class="appsero-widget" style="margin-top: 20px;">
+            <h2>Webhooks</h2>
+            <p>Configure URLs to receive HTTP POST notifications when events occur.</p>
+
+            <?php if ( ! empty( $this->message ) ) : ?>
+            <div class="notice notice-<?php echo esc_attr( $this->message_type ); ?> is-dismissible" style="max-width: 852px;">
+                <p><?php echo esc_html( $this->message ); ?></p>
+            </div>
+            <?php endif; ?>
+
+            <?php if ( ! empty( $webhooks ) ) : ?>
+            <table class="widefat striped" style="max-width: 852px; margin-bottom: 20px;">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>URL</th>
+                        <th>Events</th>
+                        <th>Status</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ( $webhooks as $webhook ) :
+                        $delete_url = wp_nonce_url(
+                            add_query_arg( [
+                                'action'     => 'delete_webhook',
+                                'webhook_id' => $webhook['id'],
+                            ], $page_url ),
+                            'delete_webhook_' . $webhook['id']
+                        );
+                    ?>
+                    <tr>
+                        <td><?php echo esc_html( $webhook['name'] ); ?></td>
+                        <td><code><?php echo esc_html( $webhook['url'] ); ?></code></td>
+                        <td><?php echo esc_html( implode( ', ', $webhook['events'] ) ); ?></td>
+                        <td><?php echo $webhook['status'] ? 'Active' : 'Inactive'; ?></td>
+                        <td>
+                            <a href="<?php echo esc_url( $delete_url ); ?>"
+                               onclick="return confirm('Delete this webhook?');"
+                               style="color: #a00;">Delete</a>
+                        </td>
+                    </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+            <?php endif; ?>
+
+            <h3>Add Webhook</h3>
+            <form method="post" autocomplete="off">
+                <table class="form-table">
+                    <tbody>
+                        <tr>
+                            <th scope="row"><label for="webhook_name">Name</label></th>
+                            <td>
+                                <input type="text" id="webhook_name" name="webhook_name" class="regular-text" placeholder="e.g. Notify Slack" required />
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row"><label for="webhook_url">URL</label></th>
+                            <td>
+                                <input type="url" id="webhook_url" name="webhook_url" class="regular-text" placeholder="https://example.com/webhook" required />
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row"><label for="webhook_secret">Secret</label></th>
+                            <td>
+                                <input type="text" id="webhook_secret" name="webhook_secret" class="regular-text" placeholder="Optional HMAC secret" />
+                                <p class="description">Used to sign payloads with HMAC-SHA256. Sent as <code>X-Appsero-Signature</code> header.</p>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Events</th>
+                            <td>
+                                <?php foreach ( self::$available_events as $key => $label ) : ?>
+                                <label style="display: block; margin-bottom: 5px;">
+                                    <input type="checkbox" name="webhook_events[]" value="<?php echo esc_attr( $key ); ?>" />
+                                    <?php echo esc_html( $label ); ?>
+                                </label>
+                                <?php endforeach; ?>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <?php wp_nonce_field( 'appsero_add_webhook', 'appsero_webhook_nonce' ); ?>
+                <?php submit_button( 'Add Webhook', 'secondary', 'appsero_webhook_submit' ); ?>
+            </form>
+        </div>
+        <?php
+    }
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -347,6 +347,10 @@ function appsero_create_customer( $email, $first_name, $last_name ) {
 
     $user_id = wp_insert_user( $userdata );
 
+    if ( ! is_wp_error( $user_id ) ) {
+        do_action( 'appsero_user_created', $user_id, $userdata );
+    }
+
     wp_send_new_user_notifications( $user_id, 'user' );
 
     return $user_id;


### PR DESCRIPTION
## Summary
- Adds outgoing webhook system that sends HTTP POST notifications to configured URLs
- Supports `user.created` event (fired when Appsero creates a new WordPress user)
- Webhooks stored in `wp_options`, managed via a new section on the Settings page
- Payloads signed with HMAC-SHA256 (`X-Appsero-Signature` header) and include `X-Api-Key`
- Non-blocking delivery via `wp_remote_post()`

## Test plan
- [ ] Go to Settings → Appsero Helper, verify Webhooks section appears below settings
- [ ] Add a webhook with a test URL (e.g. webhook.site), select `user.created` event
- [ ] Trigger user creation via Appsero REST endpoint `POST /native-users`
- [ ] Verify HTTP POST received at the configured URL with correct JSON payload
- [ ] Verify `X-Appsero-Signature` header matches `sha256=` + HMAC-SHA256 of body
- [ ] Delete webhook, confirm it is removed from the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)